### PR TITLE
Add back-to-list buttons for research pages

### DIFF
--- a/research.html
+++ b/research.html
@@ -119,7 +119,7 @@
                         <h2 class="text-xl sm:text-2xl font-bold text-white mt-1" data-lang="report1_title">솔라나 생태계 심층 분석</h2>
                     </div>
                     <div class="mt-4 sm:mt-0">
-                        <a href="https://aqcafe.mycafe24.com/rsc/aqrsc001.html" target="_blank" rel="noopener noreferrer" class="group inline-flex items-center justify-center gap-2 rounded-lg px-5 py-2.5 bg-slate-800 text-slate-100 font-semibold shadow-lg hover:bg-sky-500 hover:text-white focus-visible:outline-none transition-colors duration-300">
+                        <a href="https://aqresearch.com/rsc/aqrsc001.html" target="_blank" rel="noopener noreferrer" class="group inline-flex items-center justify-center gap-2 rounded-lg px-5 py-2.5 bg-slate-800 text-slate-100 font-semibold shadow-lg hover:bg-sky-500 hover:text-white focus-visible:outline-none transition-colors duration-300">
                           <span data-lang="view_report_cta">리포트 보기</span>
                           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 transition-transform group-hover:translate-x-1" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
                         </a>
@@ -136,7 +136,7 @@
                         <h2 class="text-xl sm:text-2xl font-bold text-white mt-1" data-lang="report2_title">Sharps Technology(STSS) 심층 분석</h2>
                     </div>
                     <div class="mt-4 sm:mt-0">
-                        <a href="https://aqcafe.mycafe24.com/rsc/aqrsc002.html" target="_blank" rel="noopener noreferrer" class="group inline-flex items-center justify-center gap-2 rounded-lg px-5 py-2.5 bg-slate-800 text-slate-100 font-semibold shadow-lg hover:bg-sky-500 hover:text-white focus-visible:outline-none transition-colors duration-300">
+                        <a href="https://aqresearch.com/rsc/aqrsc002.html" target="_blank" rel="noopener noreferrer" class="group inline-flex items-center justify-center gap-2 rounded-lg px-5 py-2.5 bg-slate-800 text-slate-100 font-semibold shadow-lg hover:bg-sky-500 hover:text-white focus-visible:outline-none transition-colors duration-300">
                           <span data-lang="view_report_cta">리포트 보기</span>
                           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 transition-transform group-hover:translate-x-1" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
                         </a>

--- a/rsc/aqrsc001.html
+++ b/rsc/aqrsc001.html
@@ -151,6 +151,7 @@
     </style>
 </head>
 <body class="antialiased">
+    <a href="https://aqresearch.com/research.html" class="absolute top-4 left-4 bg-gray-200 text-gray-700 px-3 py-1 rounded hover:bg-gray-300">Back to list</a>
     <div class="container mx-auto px-4 lg:px-8 py-8 max-w-5xl">
         
         <div class="print-first-page">

--- a/rsc/aqrsc002.html
+++ b/rsc/aqrsc002.html
@@ -96,7 +96,7 @@
     </style>
 </head>
 <body class="antialiased">
-
+    <a href="https://aqresearch.com/research.html" class="absolute top-4 left-4 bg-gray-200 text-gray-700 px-3 py-1 rounded hover:bg-gray-300">Back to list</a>
     <div class="container mx-auto px-4 lg:px-8 py-8 max-w-4xl">
         
         <header class="aquila-header text-center pb-6 mb-8">


### PR DESCRIPTION
## Summary
- Add top-left "Back to list" button linking to the research list on aqrsc001.html and aqrsc002.html
- Update "View Report" links on research.html to point to aqresearch.com domain

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b921735e74832396efcea1f3dd515a